### PR TITLE
Add multi-stage build Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.11 as builder
+
+RUN apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y git
+WORKDIR /go/src/splunk_modinput_prometheus
+COPY . /go/src/splunk_modinput_prometheus
+
+RUN go get github.com/gogo/protobuf/proto
+RUN go get github.com/golang/snappy
+RUN go get github.com/prometheus/common/model
+RUN go get github.com/prometheus/prometheus/prompb
+RUN go get github.com/gobwas/glob
+RUN go get github.com/prometheus/prometheus/pkg/textparse
+
+FROM debian:stretch-slim
+COPY --from=builder /go/src/splunk_modinput_prometheus/modinput_prometheus/ /opt/modinput_prometheus
+


### PR DESCRIPTION
This adds a Dockerfile that,

 - Builds the TA in a builder container
 - Copies the built asset to a debian-slim image for the resulting artifact container

The primary use case is for copying the TA into a volume shared with a Splunk container (i.e. using k8s [`initContainers`](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/))