### PR TITLE
update code to fix prometheus ver2.5

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -190,7 +190,8 @@ func run() {
 	defer output.Flush()
 
 	// Need to parse metrics out of body individually to convert from scientific to decimal etc. before handing to Splunk
-	p := textparse.New(body)
+	contentType := resp.Header.Get("Content-Type")
+	p := textparse.New(body, contentType)
 
 	for {
 		et, err := p.Next()


### PR DESCRIPTION
Hi, when build this package, I found following error message.

```Bash
go build prometheus.go
# command-line-argumentscd 
./prometheus.go:193:20: not enough arguments in call to textparse.New
	have ([]byte)
	want ([]byte, string)
```

Because in Prometheus v2.5.0, `textparse` has changed a lot. Currently it need a argument to represent `Content-Type`. 
https://github.com/prometheus/prometheus/blob/master/pkg/textparse/interface.go#L59