### PR TITLE
Label match value activation. Breaking change as coma separator is no…

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The index should be a "metrics" type index. The sourcetype should be prometheus:
 
 ### Federate server
 
-This configuration is to gather all metrics from a Prometheus server. At least one valid "match" must be supplied in order to get any data from a Prometheus federation endpoint. Eatch "match" is entered with comma separation in the Splunk configuration. The example "match" string given here matches all metrics. You can learn more about how to configure metrics matching at: https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors
+This configuration is to gather all metrics from a Prometheus server. At least one valid "match" must be supplied in order to get any data from a Prometheus federation endpoint. Eatch "match" is entered with semicolon separation in the Splunk configuration. The example "match" string given here matches all metrics. You can learn more about how to configure metrics matching at: https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors
 
 ```
 [prometheus://prom-server-1]

--- a/modinput_prometheus/README/inputs.conf.spec
+++ b/modinput_prometheus/README/inputs.conf.spec
@@ -43,7 +43,7 @@ URI = <URI>
 * The full URI of the exporter to connect to
 
 match = <match expression>,<match expression>,...
-* Match expressions, comma separated
+* Match expressions, semicolon separated
 * At least one valid match expression must be included if you are connecting to a Prometheus federate endpoint
 * They are usually ignored for most exporters, however
 


### PR DESCRIPTION
… longer used to split match query parameters. In order to also support label matching we change from comma to semi-colon separator