### PR TITLE
Addition of username/password into the prometheus modular input stanza

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 build:
+	make -B prometheusrw
 	make -B prometheus
+
+prometheusrw: prometheusrw/prometheusrw.go
+	go build -o ./out/prometheusrw ./prometheusrw/prometheusrw.go
+
+	mv ./out/prometheusrw modinput_prometheus/linux_x86_64/bin/
 
 prometheus: prometheus/prometheus.go
 	go build  -o ./out/prometheus ./prometheus/prometheus.go

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,5 @@
 build:
-	make -B prometheusrw
 	make -B prometheus
-
-prometheusrw: prometheusrw/prometheusrw.go
-	go build -o ./out/prometheusrw ./prometheusrw/prometheusrw.go
-
-	mv ./out/prometheusrw modinput_prometheus/linux_x86_64/bin/
 
 prometheus: prometheus/prometheus.go
 	go build  -o ./out/prometheus ./prometheus/prometheus.go

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ sourcetype = prometheus:metric
 host = myhost
 interval = 60
 disabled = 0
+username = <optional username>
+password = <optional password>
 ```
 
 The index should be a "metrics" type index. The sourcetype should be prometheus:metric, which is configured in the app to recognize the data format and convert it to Splunk metrics.
@@ -150,6 +152,8 @@ sourcetype = prometheus:metric
 host = myhost
 interval = 60
 disabled = 0
+username = <optional username>
+password = <optional password>
 ```
 
 ### Prometheus remote-write

--- a/modinput_prometheus/README/inputs.conf.spec
+++ b/modinput_prometheus/README/inputs.conf.spec
@@ -57,3 +57,9 @@ match = <match expression>,<match expression>,...
 
 insecureSkipVerify = <0|1>
 * If the URI is HTTPS, this controls whether the server certificate must be verified in order to continue
+
+username = <string>
+* Provide an optional username to be used with the Prometheus federate endpoint
+
+password = <string>
+* Provide an optional password to be used with the Prometheus federate endpoint

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -55,6 +55,8 @@ type inputConfig struct {
 	Index              string
 	Sourcetype         string
 	Host               string
+	Username           string
+	Password           string
 }
 
 var (
@@ -173,6 +175,18 @@ func doScheme() string {
 						<required_on_edit>false</required_on_edit>
 						<required_on_create>false</required_on_create>
 					</arg>
+					<arg name="username">
+						<title>Username</title>
+						<description>If supplied uses a username in basic auth requests to the endpoint</description>
+						<required_on_edit>false</required_on_edit>
+						<required_on_create>false</required_on_create>
+					</arg>
+					<arg name="password">
+						<title>Password</title>
+						<description>If supplied uses a password in basic auth requests to the endpoint</description>
+						<required_on_edit>false</required_on_edit>
+						<required_on_create>false</required_on_create>
+					</arg>
       </endpoint>
     </scheme>`
 
@@ -215,6 +229,12 @@ func config() inputConfig {
 					inputConfig.Match = append(inputConfig.Match, m)
 				}
 			}
+			if p.Name == "username" {
+					inputConfig.Username = p.Value
+			}
+			if p.Name == "password" {
+					inputConfig.Password = p.Value
+			}
 		}
 	}
 
@@ -245,6 +265,11 @@ func run() {
 
 	// Debug request req.URL
 	logDebug.Print(req.URL)
+
+	if inputConfig.Password != "" {
+			req.SetBasicAuth(inputConfig.Username, inputConfig.Password)
+			logDebug.Print(inputConfig.Username)
+	}
 
 	// Current timestamp in millis, used if response has no timestamps
 	now := time.Now().UnixNano() / int64(time.Millisecond)


### PR DESCRIPTION
This allows a username/password to work with a remote Prometheus server, tested on a federate endpoint